### PR TITLE
Pass CMake args to cross-compile

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,7 +5,7 @@ set -e
 
 mkdir build
 cd build
-cmake .. -DCMAKE_INSTALL_PREFIX="$PREFIX" -DCMAKE_INSTALL_LIBDIR="lib" -DCMAKE_BUILD_TYPE=Release -GNinja
+cmake ${CMAKE_ARGS} .. -DCMAKE_INSTALL_PREFIX="$PREFIX" -DCMAKE_INSTALL_LIBDIR="lib" -DCMAKE_BUILD_TYPE=Release -GNinja
 ninja install   # Install C++ library into Conda env
 cd ../python
 ${PYTHON} setup.py install --single-version-externally-managed --record=record.txt

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 0001-remove-distutils.patch
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:


### PR DESCRIPTION
It is necessary to set `${CMAKE_ARGS}` so that CMake can properly configure cross-compilation.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
