### PR TITLE
Pin RapidJSON to stable 1.1.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - cmake >=3.14
     - ninja
     - fmt
-    - rapidjson>=1.1.0,<1.1.0.post*
+    - rapidjson >=1.1.0,<1.1.0.post*
     - llvm-openmp  # [osx]
     - libgomp  # [linux]
     - {{ compiler('c') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 0001-Open-libtreelite.so-with-global-visibility.patch
 
 build:
-  number: 1
+  number: 2
   skip: true  # [python_impl == 'pypy' and win]
 
 requirements:
@@ -22,7 +22,7 @@ requirements:
     - cmake >=3.14
     - ninja
     - fmt
-    - rapidjson
+    - rapidjson>=1.1.0,<1.1.0.post*
     - llvm-openmp  # [osx]
     - libgomp  # [linux]
     - {{ compiler('c') }}


### PR DESCRIPTION
Recently, Conda-forge released a new version of RapidJSON, 1.1.0.post20240409. While it was meant to be a cosmetic change on top of 1.1.0, it is affected by a bug in CMake build (https://github.com/conda-forge/rapidjson-feedstock/issues/8, https://github.com/Tencent/rapidjson/pull/2193).

Fix: Pin RapidJSON to stable 1.1.0 version.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
